### PR TITLE
fix: Add missing tailwindcss-animate dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
+    "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.2.2",
     "vite": "^5.1.0"
   }


### PR DESCRIPTION
## Summary
Fixes frontend build failure due to missing Tailwind CSS animation plugin.

## Problem
Build was failing with:
```
Cannot find module 'tailwindcss-animate'
```

## Solution
Added `tailwindcss-animate` to devDependencies in frontend/package.json.

## Testing
- [x] Dependency added to package.json
- [ ] Build completes successfully on Render

This is a critical hotfix to unblock frontend deployment.

🤖 Generated with [Claude Code](https://claude.ai/code)